### PR TITLE
resource to API 500 Synergy

### DIFF
--- a/lib/oneview-sdk/resource/api600/synergy/logical_interconnect_group.rb
+++ b/lib/oneview-sdk/resource/api600/synergy/logical_interconnect_group.rb
@@ -9,13 +9,13 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-require_relative '../c7000/logical_interconnect_group'
+require_relative '../../api500/synergy/logical_interconnect_group'
 
 module OneviewSDK
   module API600
     module Synergy
       # Logical interconnect group resource implementation for API600 Synergy
-      class LogicalInterconnectGroup < OneviewSDK::API600::C7000::LogicalInterconnectGroup
+      class LogicalInterconnectGroup < OneviewSDK::API500::Synergy::LogicalInterconnectGroup
       end
     end
   end


### PR DESCRIPTION
The resource was set to C7000, but most of the Logical Interconnect Group functionalitys for the Synergy are build in '../../api300/synergy'.
The recource for api500 is also set to api300.

### Description
[Describe what this change achieves]
Enables more Logical Interconnect Group functionalitys for API 600.
### Issues Resolved
[List any issues this PR will resolve. e.g., Fixes #01]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [ ] New endpoints supported are updated in the endpoints-support.md file.
- [ ] Changes are documented in the CHANGELOG.
